### PR TITLE
Add RangeComponent and some styling fixes.

### DIFF
--- a/player-client/src/components/V2/RangeComponent.vue
+++ b/player-client/src/components/V2/RangeComponent.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import type { Socket } from "socket.io-client";
+import { inject, reactive, onMounted, onUnmounted } from "vue";
+const socket: Socket = inject("socket") as Socket;
+
+let mountedAt: number;
+
+const defaultProps = {
+  event: "range",
+  min: 0,
+  max: 100,
+  step: 1,
+  style: {
+    color: "black",
+    align: "left",
+    background: "white",
+    border: "2px solid black",
+    fontSize: "16px",
+    borderRadius: "0px",
+  },
+};
+
+const customProps = defineProps(["custom"]);
+const props = {
+  ...defaultProps,
+  ...customProps.custom,
+  style: { ...defaultProps.style, ...customProps.custom.style },
+};
+
+const inputState = reactive({
+  value: 0,
+  submitted: false,
+});
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Enter") respond();
+};
+
+const respond = () => {
+  inputState.submitted = true;
+  window.removeEventListener("keydown", handleKeydown);
+  socket.emit("msg", {
+    event: props.event,
+    value: String(inputState.value),
+    ms: Date.now() - mountedAt,
+  });
+};
+
+onMounted(() => {
+  mountedAt = Date.now();
+  window.addEventListener("keydown", handleKeydown);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("keydown", handleKeydown);
+});
+</script>
+
+<template>
+  <div class="range-input-wrapper">
+    <input
+      class="range-input"
+      type="range"
+      v-model="inputState.value"
+      :min="props.min"
+      :max="props.max"
+      :step="props.step"
+      :disabled="inputState.submitted"
+    />
+    <input
+      class="range-text-input"
+      type="number"
+      autofocus
+      v-model="inputState.value"
+      :min="props.min"
+      :max="props.max"
+      :step="props.step"
+      :disabled="inputState.submitted"
+    />
+    <button @click="respond" class="submit-button">
+      <font-awesome-icon
+        v-if="inputState.submitted"
+        class="submit-icon"
+        icon="fa-solid fa-check"
+      />
+      <font-awesome-icon
+        v-if="!inputState.submitted"
+        class="submit-icon"
+        icon="fa-solid fa-paper-plane"
+      />
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.range-input-wrapper {
+  display: flex;
+  flex-direction: row;
+  border: v-bind("props.style.border");
+  border-radius: v-bind("props.style.borderRadius");
+  background: v-bind("props.style.background");
+}
+
+.range-input {  
+  margin: 0;
+  padding: 10px 0;
+  flex-grow: 1;
+}
+
+.range-input:disabled {
+  opacity: 0.6;
+}
+
+.range-text-input {
+  display: flex;
+  border: none;
+  color: v-bind("props.style.color");
+  background: transparent;
+  font-size: v-bind("props.style.fontSize");
+  margin: 0;
+  padding: 10px 5px;
+  width: 25%;
+  text-align: center;  
+}
+
+.range-text-input::-webkit-inner-spin-button {
+  opacity:1;
+}
+
+.range-text-input:disabled {
+  opacity: 0.6;
+}
+
+.submit-button {
+  font-size: v-bind("props.style.fontSize");
+  border: none;
+  border-radius: v-bind("props.style.borderRadius");
+  background: v-bind("props.style.background");
+  padding: 10px;
+}
+
+.submit-icon {
+  color: v-bind("props.style.color");
+}
+</style>

--- a/player-client/src/components/V2/RangeComponent.vue
+++ b/player-client/src/components/V2/RangeComponent.vue
@@ -70,7 +70,6 @@ onUnmounted(() => {
     <input
       class="range-text-input"
       type="number"
-      autofocus
       v-model="inputState.value"
       :min="props.min"
       :max="props.max"

--- a/player-client/src/components/V2/TextInputComponent.vue
+++ b/player-client/src/components/V2/TextInputComponent.vue
@@ -13,6 +13,7 @@ const defaultProps = {
     background: "white",
     border: "2px solid black",
     fontSize: "30px",
+    borderRadius: "0px"
   },
 };
 
@@ -81,6 +82,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: row;
   border: v-bind("props.style.border");
+  border-radius: v-bind("props.style.borderRadius");
   background: v-bind("props.style.background");
 }
 
@@ -102,6 +104,7 @@ onUnmounted(() => {
 .submit-button {
   font-size: v-bind("props.style.fontSize");
   border: none;
+  border-radius: v-bind("props.style.borderRadius");
   background: v-bind("props.style.background");
   padding: 10px;
 }

--- a/player-client/src/components/V2/TextInputComponent.vue
+++ b/player-client/src/components/V2/TextInputComponent.vue
@@ -20,7 +20,7 @@ const customProps = defineProps(["custom"]);
 const props = {
   ...defaultProps,
   ...customProps.custom,
-  style: { ...defaultProps.style, ...customProps.custom },
+  style: { ...defaultProps.style, ...customProps.custom.style },
 };
 
 const inputState = reactive({
@@ -86,7 +86,7 @@ onUnmounted(() => {
 
 .text-input {
   border: none;
-  color: v-bind("props.color");
+  color: v-bind("props.style.color");
   background: transparent;
   font-size: v-bind("props.style.fontSize");
   margin: 0;

--- a/player-client/src/components/V2/index.ts
+++ b/player-client/src/components/V2/index.ts
@@ -3,6 +3,7 @@ import ChoicesComponent from "./ChoicesComponent.vue";
 import TextComponent from "./TextComponent.vue";
 import ButtonComponent from "./ButtonComponent.vue";
 import TextInputComponent from "./TextInputComponent.vue";
+import RangeComponent from "./RangeComponent.vue";
 
 export default {
   BuzzerComponent,
@@ -10,4 +11,5 @@ export default {
   TextComponent,
   ButtonComponent,
   TextInputComponent,
+  RangeComponent,
 };

--- a/player-client/src/components/index.ts
+++ b/player-client/src/components/index.ts
@@ -18,4 +18,5 @@ export default {
   V2TextComponent: V2.TextComponent,
   V2ButtonComponent: V2.ButtonComponent,
   V2TextInputComponent: V2.TextInputComponent,
+  V2RangeComponent: V2.RangeComponent,
 };


### PR DESCRIPTION
**_RangeComponent_** consists of 2 `<input>` elements, one a `"range"` type, and the other a `"number"` type. The range slider affects the number input and vice versa. On submitting the input, it fires an event and the value is a stringified version of the number, to maintain the expected type for `value` of an event.
It has a few configurable props in addition to the style props that were borrowed from the _TextInputComponent_:
- `"min"`: Controls the minimum value, defaults to 0
- `"max"`: Controls the maximum value, defaults to 100
- `"step"`: Controls the step between increments on the slider and the spinner, defaults to 1

I've also included a couple fixes to the styling not correctly hooking up for the TextInput component, and also exposed the `"borderRadius"` style prop for the TextInput component as well.