### PR TITLE
Fix preset & component style spreading issues.

### DIFF
--- a/player-client/src/lib/stateHelpers.ts
+++ b/player-client/src/lib/stateHelpers.ts
@@ -6,7 +6,7 @@ const expandStatePresets = (state: PlayerStatePayload): PlayerStatePayload => {
     const preset = presets[component.type];
     if (!preset) return component;
 
-    const props = { ...preset.props, ...component.props };
+    const props = { ...preset.props, ...component.props, style: { ...preset.props.style, ...component.props.style } };
     return { key: component.key, type: preset.type, props };
   });
 


### PR DESCRIPTION
See details [in Discord](https://discord.com/channels/1022900968129560699/1022901447190384671/1095023251811471441). Boils down to the style properties now being one level deeper than the root of `props`, and so the spread operation now doesn't copy deep enough.