### PR TITLE
client: add `persistent` option to Button for repeatable presses

### DIFF
--- a/client/src/components/ButtonComponent.vue
+++ b/client/src/components/ButtonComponent.vue
@@ -14,6 +14,9 @@ const props = mergeProps(
     label: "A: 42",
     value: "A",
     keys: ["A", "1"],
+    // When true the button never disables after a press, so it can be tapped
+    // repeatedly without the host re-pushing state to re-arm it.
+    persistent: false,
   },
   custom,
 );
@@ -27,7 +30,7 @@ const state: State = reactive({
 });
 
 const respond = () => {
-  state.submitted = true;
+  if (!props.persistent) state.submitted = true;
 
   socket.emit("msg", {
     event: props.event,
@@ -47,6 +50,7 @@ onMounted(() => {
     :label="props.label"
     :keys="props.keys"
     :style="props.style"
+    :persistent="props.persistent"
     :disabled="state.submitted"
   ></choice-button>
 </template>

--- a/client/src/components/Choices/ChoiceButton.vue
+++ b/client/src/components/Choices/ChoiceButton.vue
@@ -21,6 +21,9 @@ export interface Props {
   style: Partial<StyleProps>;
   keys?: string[];
   onSelect?: () => void;
+  // Repeatable button: fire on every press without latching into a
+  // selected/disabled state, so the host needn't re-push to re-arm it.
+  persistent?: boolean;
 }
 
 export interface State {
@@ -57,6 +60,7 @@ const customProps = withDefaults(defineProps<Props>(), {
   label: () => "",
   keys: () => [],
   style: () => ({}),
+  persistent: false,
 });
 
 const props = {
@@ -85,6 +89,11 @@ const handleKeydown = (event: KeyboardEvent) => {
 };
 
 const handleSelect = () => {
+  if (props.persistent) {
+    // Stay enabled so the player can press again and again.
+    props.onSelect();
+    return;
+  }
   state.selected = !state.selected;
   props.onSelect();
 };

--- a/docs/content/1.docs/3.components.md
+++ b/docs/content/1.docs/3.components.md
@@ -68,6 +68,7 @@ Button that sends a predefined message back to the host when triggered.
     "label": "A: 42",
     "value": "A",
     "keys": ["A", "1"], // Keyboard keys that can be used to trigger the button.
+    "persistent": false, // If persistent, the button stays enabled so it can be pressed repeatedly.
     "style": {
       "color": "black",
       "align": "center",


### PR DESCRIPTION
## What

Adds a `persistent` prop to the **Button** component so a button can be pressed repeatedly without the host re-pushing state to re-arm it.

Today a Button latches after a single press: `ButtonComponent` sets `submitted`, and the underlying `ChoiceButton` disables itself on `selected`. To accept another press the host has to push a fresh state (which remounts the component). This mirrors the existing `TextInput.persistent` option for the Button.

## Changes

- **`ChoiceButton.vue`** — new optional `persistent` prop (default `false`). When set, `handleSelect` fires `onSelect` without toggling `selected`, so the button never enters its disabled state.
- **`ButtonComponent.vue`** — adds the `persistent` default, skips the `submitted` lock when it's set, and passes `:persistent` through to `ChoiceButton`.
- **docs** — documents the new Button `persistent` prop (alongside the existing `TextInput` one).

## Usage

```json
{ "type": "Button", "props": { "label": "Buzz", "event": "buzz", "persistent": true } }
```

## Compatibility

- Default is `false`, so all existing Buttons behave exactly as before.
- Other `ChoiceButton` consumers (`Choices`, `Sort`) don't pass the prop and are unaffected.
- `vue-tsc` type-check passes.

## Why

Driven by [hackbox-to-keyboard](https://github.com/devanhurst/hackbox-to-keyboard), where every player button maps to an OS keypress and must be tappable repeatedly. With persistent buttons the host can stop re-pushing the layout after every event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)